### PR TITLE
Switch debug prints to logging

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -7,6 +7,8 @@ import sys
 import shutil
 from pathlib import Path
 
+log = logging.getLogger(__name__)
+
 import markdown
 from bs4 import BeautifulSoup
 from open_webui.constants import ERROR_MESSAGES
@@ -16,20 +18,20 @@ from open_webui.constants import ERROR_MESSAGES
 ####################################
 
 OPEN_WEBUI_DIR = Path(__file__).parent  # the path containing this file
-print(OPEN_WEBUI_DIR)
+log.debug(OPEN_WEBUI_DIR)
 
 BACKEND_DIR = OPEN_WEBUI_DIR.parent  # the path containing this file
 BASE_DIR = BACKEND_DIR.parent  # the path containing the backend/
 
-print(BACKEND_DIR)
-print(BASE_DIR)
+log.debug(BACKEND_DIR)
+log.debug(BASE_DIR)
 
 try:
     from dotenv import find_dotenv, load_dotenv
 
     load_dotenv(find_dotenv(str(BASE_DIR / ".env")))
 except ImportError:
-    print("dotenv not installed, skipping...")
+    log.info("dotenv not installed, skipping...")
 
 DOCKER = os.environ.get("DOCKER", "False").lower() == "true"
 
@@ -71,7 +73,6 @@ if GLOBAL_LOG_LEVEL in logging.getLevelNamesMapping():
 else:
     GLOBAL_LOG_LEVEL = "INFO"
 
-log = logging.getLogger(__name__)
 log.info(f"GLOBAL_LOG_LEVEL: {GLOBAL_LOG_LEVEL}")
 
 if "cuda_error" in locals():

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -435,7 +435,7 @@ from open_webui.utils.redis import get_sentinels_from_env
 
 
 if SAFE_MODE:
-    print("SAFE MODE ENABLED")
+    log.info("SAFE MODE ENABLED")
     Functions.deactivate_all_functions()
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
@@ -458,7 +458,7 @@ class SPAStaticFiles(StaticFiles):
                 raise ex
 
 
-print(
+log.info(
     rf"""
  ██████╗ ██████╗ ███████╗███╗   ██╗    ██╗    ██╗███████╗██████╗ ██╗   ██╗██╗
 ██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██║    ██║██╔════╝██╔══██╗██║   ██║██║
@@ -1359,7 +1359,7 @@ async def list_tasks_by_chat_id_endpoint(chat_id: str, user=Depends(get_verified
 
     task_ids = list_task_ids_by_chat_id(chat_id)
 
-    print(f"Task IDs for chat {chat_id}: {task_ids}")
+    log.debug(f"Task IDs for chat {chat_id}: {task_ids}")
     return {"task_ids": task_ids}
 
 

--- a/backend/open_webui/migrations/versions/1af9b942657b_migrate_tags.py
+++ b/backend/open_webui/migrations/versions/1af9b942657b_migrate_tags.py
@@ -12,6 +12,11 @@ from sqlalchemy.sql import table, select, update, column
 from sqlalchemy.engine.reflection import Inspector
 
 import json
+import logging
+from open_webui.env import SRC_LOG_LEVELS
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["DB"])
 
 revision = "1af9b942657b"
 down_revision = "242a2047eae0"
@@ -74,7 +79,7 @@ def upgrade():
         tag_updates[row.id] = new_id
 
     for tag_id, new_tag_id in tag_updates.items():
-        print(f"Updating tag {tag_id} to {new_tag_id}")
+        log.info(f"Updating tag {tag_id} to {new_tag_id}")
         if new_tag_id == "pinned":
             # delete tag
             delete_stmt = sa.delete(tag).where(tag.c.id == tag_id)
@@ -86,7 +91,7 @@ def upgrade():
 
             if existing_tag_result:
                 # Handle duplicate case: the new_tag_id already exists
-                print(
+                log.info(
                     f"Tag {new_tag_id} already exists. Removing current tag with ID {tag_id} to avoid duplicates."
                 )
                 # Option 1: Delete the current tag if an update to new_tag_id would cause duplication

--- a/backend/open_webui/migrations/versions/242a2047eae0_update_chat_table.py
+++ b/backend/open_webui/migrations/versions/242a2047eae0_update_chat_table.py
@@ -11,6 +11,11 @@ import sqlalchemy as sa
 from sqlalchemy.sql import table, select, update
 
 import json
+import logging
+from open_webui.env import SRC_LOG_LEVELS
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["DB"])
 
 revision = "242a2047eae0"
 down_revision = "6a39f3d8e55c"
@@ -30,20 +35,20 @@ def upgrade():
 
     if chat_column:
         if isinstance(chat_column["type"], sa.Text):
-            print("Converting 'chat' column to JSON")
+            log.info("Converting 'chat' column to JSON")
 
             if old_chat_exists:
-                print("Dropping old 'old_chat' column")
+                log.info("Dropping old 'old_chat' column")
                 op.drop_column("chat", "old_chat")
 
             # Step 1: Rename current 'chat' column to 'old_chat'
-            print("Renaming 'chat' column to 'old_chat'")
+            log.info("Renaming 'chat' column to 'old_chat'")
             op.alter_column(
                 "chat", "chat", new_column_name="old_chat", existing_type=sa.Text()
             )
 
             # Step 2: Add new 'chat' column of type JSON
-            print("Adding new 'chat' column of type JSON")
+            log.info("Adding new 'chat' column of type JSON")
             op.add_column("chat", sa.Column("chat", sa.JSON(), nullable=True))
         else:
             # If the column is already JSON, no need to do anything
@@ -74,7 +79,7 @@ def upgrade():
         )
 
     # Step 4: Drop 'old_chat' column
-    print("Dropping 'old_chat' column")
+    log.info("Dropping 'old_chat' column")
     op.drop_column("chat", "old_chat")
 
 

--- a/backend/open_webui/migrations/versions/6a39f3d8e55c_add_knowledge_table.py
+++ b/backend/open_webui/migrations/versions/6a39f3d8e55c_add_knowledge_table.py
@@ -10,6 +10,11 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.sql import table, column, select
 import json
+import logging
+from open_webui.env import SRC_LOG_LEVELS
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["DB"])
 
 
 revision = "6a39f3d8e55c"
@@ -20,7 +25,7 @@ depends_on = None
 
 def upgrade():
     # Creating the 'knowledge' table
-    print("Creating knowledge table")
+    log.info("Creating knowledge table")
     knowledge_table = op.create_table(
         "knowledge",
         sa.Column("id", sa.Text(), primary_key=True),
@@ -33,7 +38,7 @@ def upgrade():
         sa.Column("updated_at", sa.BigInteger(), nullable=True),
     )
 
-    print("Migrating data from document table to knowledge table")
+    log.info("Migrating data from document table to knowledge table")
     # Representation of the existing 'document' table
     document_table = table(
         "document",

--- a/backend/open_webui/retrieval/web/bing.py
+++ b/backend/open_webui/retrieval/web/bing.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from pprint import pprint
 from typing import Optional
 import requests
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
@@ -70,4 +69,4 @@ def main():
     args = parser.parse_args()
 
     results = search_bing(args.locale, args.query, args.count, args.filter)
-    pprint(results)
+    log.debug(results)

--- a/backend/open_webui/retrieval/web/bocha.py
+++ b/backend/open_webui/retrieval/web/bocha.py
@@ -53,7 +53,7 @@ def search_bocha(
     response = requests.post(url, headers=headers, data=payload, timeout=5)
     response.raise_for_status()
     results = _parse_response(response.json())
-    print(results)
+    log.debug(results)
     if filter_list:
         results = get_filtered_results(results, filter_list)
 

--- a/backend/open_webui/retrieval/web/kagi.py
+++ b/backend/open_webui/retrieval/web/kagi.py
@@ -40,7 +40,7 @@ def search_kagi(
         if result["t"] == 0
     ]
 
-    print(results)
+    log.debug(results)
 
     if filter_list:
         results = get_filtered_results(results, filter_list)

--- a/backend/open_webui/retrieval/web/mojeek.py
+++ b/backend/open_webui/retrieval/web/mojeek.py
@@ -28,7 +28,7 @@ def search_mojeek(
     response.raise_for_status()
     json_response = response.json()
     results = json_response.get("response", {}).get("results", [])
-    print(results)
+    log.debug(results)
     if filter_list:
         results = get_filtered_results(results, filter_list)
 

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -800,7 +800,7 @@ def transcribe(request: Request, file_path: str, metadata: Optional[dict] = None
     # Always produce a list of chunk paths (could be one entry if small)
     try:
         chunk_paths = split_audio(file_path, MAX_FILE_SIZE)
-        print(f"Chunk paths: {chunk_paths}")
+        log.debug(f"Chunk paths: {chunk_paths}")
     except Exception as e:
         log.exception(e)
         raise HTTPException(

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -101,7 +101,7 @@ def get_tools(
 
                     def make_tool_function(function_name, token, tool_server_data):
                         async def tool_function(**kwargs):
-                            print(
+                            log.debug(
                                 f"Executing tool function {function_name} with params: {kwargs}"
                             )
                             return await execute_tool_server(

--- a/contribution_stats.py
+++ b/contribution_stats.py
@@ -1,6 +1,9 @@
 import os
 import subprocess
+import logging
 from collections import Counter
+
+log = logging.getLogger(__name__)
 
 CONFIG_FILE_EXTENSIONS = (".json", ".yml", ".yaml", ".ini", ".conf", ".toml")
 
@@ -35,7 +38,7 @@ def get_tracked_files():
         files = [f for f in files if f and os.path.isfile(f)]
         return files
     except subprocess.CalledProcessError:
-        print("Error: Are you in a git repository?")
+        log.error("Error: Are you in a git repository?")
         return []
 
 
@@ -67,7 +70,7 @@ def main():
 
     for email, lines in email_counter.most_common():
         percent = (lines / total_lines * 100) if total_lines else 0
-        print(f"{email}: {lines}/{total_lines} {percent:.2f}%")
+        log.info(f"{email}: {lines}/{total_lines} {percent:.2f}%")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- convert debugging `print` calls into proper logging across the backend
- remove leftover prints from migrations and tools
- replace CLI output in `contribution_stats.py` with logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6842009f95f0833391ed0802a40b607f