### PR TITLE
Add retryable HTTP helper and replace request calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ If you are running Open WebUI in an offline environment, you can set the `HF_HUB
 export HF_HUB_OFFLINE=1
 ```
 
+### HTTP Request Timeout
+
+Internal network calls use a default timeout of 10 seconds. You can customize this value by setting the `HTTP_REQUEST_TIMEOUT` environment variable:
+
+```bash
+export HTTP_REQUEST_TIMEOUT=30
+```
+
 ## What's Next? 🌟
 
 Discover upcoming features on our roadmap in the [Open WebUI Documentation](https://docs.openwebui.com/roadmap/).

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -19,6 +19,8 @@ from aiocache import cached
 import aiohttp
 import anyio.to_thread
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 
 
 from fastapi import (
@@ -1574,7 +1576,9 @@ async def oauth_callback(provider: str, request: Request, response: Response):
 @app.get("/manifest.json")
 async def get_manifest_json():
     if app.state.EXTERNAL_PWA_MANIFEST_URL:
-        return requests.get(app.state.EXTERNAL_PWA_MANIFEST_URL).json()
+        return http_request_with_retry(
+            "get", app.state.EXTERNAL_PWA_MANIFEST_URL, timeout=HTTP_REQUEST_TIMEOUT.value
+        ).json()
     else:
         return {
             "name": app.state.WEBUI_NAME,

--- a/backend/open_webui/retrieval/loaders/external_web.py
+++ b/backend/open_webui/retrieval/loaders/external_web.py
@@ -1,4 +1,6 @@
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 import logging
 from typing import Iterator, List, Union
 
@@ -29,7 +31,8 @@ class ExternalWebLoader(BaseLoader):
         for i in range(0, len(self.urls), batch_size):
             urls = self.urls[i : i + batch_size]
             try:
-                response = requests.post(
+                response = http_request_with_retry(
+                    "post",
                     self.external_url,
                     headers={
                         "User-Agent": "Open WebUI (https://github.com/open-webui/open-webui) External Web Loader",
@@ -38,6 +41,7 @@ class ExternalWebLoader(BaseLoader):
                     json={
                         "urls": urls,
                     },
+                    timeout=HTTP_REQUEST_TIMEOUT.value,
                 )
                 response.raise_for_status()
                 results = response.json()

--- a/backend/open_webui/retrieval/web/bocha.py
+++ b/backend/open_webui/retrieval/web/bocha.py
@@ -2,6 +2,8 @@ import logging
 from typing import Optional
 
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 import json
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.env import SRC_LOG_LEVELS
@@ -50,7 +52,9 @@ def search_bocha(
         {"query": query, "summary": True, "freshness": "noLimit", "count": count}
     )
 
-    response = requests.post(url, headers=headers, data=payload, timeout=5)
+    response = http_request_with_retry(
+        "post", url, headers=headers, data=payload, timeout=HTTP_REQUEST_TIMEOUT.value
+    )
     response.raise_for_status()
     results = _parse_response(response.json())
     print(results)

--- a/backend/open_webui/retrieval/web/exa.py
+++ b/backend/open_webui/retrieval/web/exa.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 from open_webui.env import SRC_LOG_LEVELS
 from open_webui.retrieval.web.main import SearchResult
 
@@ -46,8 +48,12 @@ def search_exa(
     }
 
     try:
-        response = requests.post(
-            f"{EXA_API_BASE}/search", headers=headers, json=payload
+        response = http_request_with_retry(
+            "post",
+            f"{EXA_API_BASE}/search",
+            headers=headers,
+            json=payload,
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
         response.raise_for_status()
         data = response.json()

--- a/backend/open_webui/retrieval/web/external.py
+++ b/backend/open_webui/retrieval/web/external.py
@@ -2,6 +2,8 @@ import logging
 from typing import Optional, List
 
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.env import SRC_LOG_LEVELS
 
@@ -17,7 +19,8 @@ def search_external(
     filter_list: Optional[List[str]] = None,
 ) -> List[SearchResult]:
     try:
-        response = requests.post(
+        response = http_request_with_retry(
+            "post",
             external_url,
             headers={
                 "User-Agent": "Open WebUI (https://github.com/open-webui/open-webui) RAG Bot",
@@ -27,6 +30,7 @@ def search_external(
                 "query": query,
                 "count": count,
             },
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
         response.raise_for_status()
         results = response.json()

--- a/backend/open_webui/retrieval/web/firecrawl.py
+++ b/backend/open_webui/retrieval/web/firecrawl.py
@@ -3,6 +3,8 @@ from typing import Optional, List
 from urllib.parse import urljoin
 
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.env import SRC_LOG_LEVELS
 
@@ -19,7 +21,8 @@ def search_firecrawl(
 ) -> List[SearchResult]:
     try:
         firecrawl_search_url = urljoin(firecrawl_url, "/v1/search")
-        response = requests.post(
+        response = http_request_with_retry(
+            "post",
             firecrawl_search_url,
             headers={
                 "User-Agent": "Open WebUI (https://github.com/open-webui/open-webui) RAG Bot",
@@ -29,6 +32,7 @@ def search_firecrawl(
                 "query": query,
                 "limit": count,
             },
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
         response.raise_for_status()
         results = response.json().get("data", [])

--- a/backend/open_webui/retrieval/web/jina_search.py
+++ b/backend/open_webui/retrieval/web/jina_search.py
@@ -1,6 +1,8 @@
 import logging
 
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 from open_webui.retrieval.web.main import SearchResult
 from open_webui.env import SRC_LOG_LEVELS
 from yarl import URL
@@ -31,7 +33,9 @@ def search_jina(api_key: str, query: str, count: int) -> list[SearchResult]:
     payload = {"q": query, "count": count if count <= 10 else 10}
 
     url = str(URL(jina_search_endpoint))
-    response = requests.post(url, headers=headers, json=payload)
+    response = http_request_with_retry(
+        "post", url, headers=headers, json=payload, timeout=HTTP_REQUEST_TIMEOUT.value
+    )
     response.raise_for_status()
     data = response.json()
 

--- a/backend/open_webui/retrieval/web/tavily.py
+++ b/backend/open_webui/retrieval/web/tavily.py
@@ -2,6 +2,8 @@ import logging
 from typing import Optional
 
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.env import SRC_LOG_LEVELS
 
@@ -32,7 +34,9 @@ def search_tavily(
         "Authorization": f"Bearer {api_key}",
     }
     data = {"query": query, "max_results": count}
-    response = requests.post(url, headers=headers, json=data)
+    response = http_request_with_retry(
+        "post", url, headers=headers, json=data, timeout=HTTP_REQUEST_TIMEOUT.value
+    )
     response.raise_for_status()
 
     json_response = response.json()

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -14,6 +14,8 @@ import os
 import logging
 import shutil
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 from pydantic import BaseModel
 from starlette.responses import FileResponse
 from typing import Optional
@@ -229,10 +231,12 @@ async def upload_pipeline(
 
         with open(file_path, "rb") as f:
             files = {"file": f}
-            r = requests.post(
+            r = http_request_with_retry(
+                "post",
                 f"{url}/pipelines/upload",
                 headers={"Authorization": f"Bearer {key}"},
                 files=files,
+                timeout=HTTP_REQUEST_TIMEOUT.value,
             )
 
         r.raise_for_status()
@@ -280,10 +284,12 @@ async def add_pipeline(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.post(
+        r = http_request_with_retry(
+            "post",
             f"{url}/pipelines/add",
             headers={"Authorization": f"Bearer {key}"},
             json={"url": form_data.url},
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
 
         r.raise_for_status()
@@ -363,7 +369,12 @@ async def get_pipelines(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.get(f"{url}/pipelines", headers={"Authorization": f"Bearer {key}"})
+        r = http_request_with_retry(
+            "get",
+            f"{url}/pipelines",
+            headers={"Authorization": f"Bearer {key}"},
+            timeout=HTTP_REQUEST_TIMEOUT.value,
+        )
 
         r.raise_for_status()
         data = r.json()
@@ -400,8 +411,11 @@ async def get_pipeline_valves(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.get(
-            f"{url}/{pipeline_id}/valves", headers={"Authorization": f"Bearer {key}"}
+        r = http_request_with_retry(
+            "get",
+            f"{url}/{pipeline_id}/valves",
+            headers={"Authorization": f"Bearer {key}"},
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
 
         r.raise_for_status()
@@ -439,9 +453,11 @@ async def get_pipeline_valves_spec(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.get(
+        r = http_request_with_retry(
+            "get",
             f"{url}/{pipeline_id}/valves/spec",
             headers={"Authorization": f"Bearer {key}"},
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
 
         r.raise_for_status()
@@ -480,10 +496,12 @@ async def update_pipeline_valves(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.post(
+        r = http_request_with_retry(
+            "post",
             f"{url}/{pipeline_id}/valves/update",
             headers={"Authorization": f"Bearer {key}"},
             json={**form_data},
+            timeout=HTTP_REQUEST_TIMEOUT.value,
         )
 
         r.raise_for_status()

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -5,6 +5,8 @@ import base64
 import hmac
 import hashlib
 import requests
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import HTTP_REQUEST_TIMEOUT
 import os
 
 
@@ -75,10 +77,11 @@ def override_static(path: str, content: str):
 def get_license_data(app, key):
     if key:
         try:
-            res = requests.post(
+            res = http_request_with_retry(
+                "post",
                 "https://api.openwebui.com/api/v1/license/",
                 json={"key": key, "version": "1"},
-                timeout=5,
+                timeout=HTTP_REQUEST_TIMEOUT.value,
             )
 
             if getattr(res, "ok", False):

--- a/backend/open_webui/utils/http.py
+++ b/backend/open_webui/utils/http.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Iterable
+
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+log = logging.getLogger(__name__)
+
+
+def http_request_with_retry(
+    method: str,
+    url: str,
+    *,
+    timeout: float | int = 10,
+    retries: int = 3,
+    backoff_factor: float = 0.5,
+    status_forcelist: Iterable[int] = (500, 502, 503, 504),
+    **kwargs,
+) -> requests.Response:
+    """Send an HTTP request with retry logic.
+
+    Parameters
+    ----------
+    method: HTTP method such as "get" or "post".
+    url: URL to request.
+    timeout: Timeout in seconds for the request.
+    retries: Number of retry attempts on failure.
+    backoff_factor: Factor for calculating sleep time between retries.
+    status_forcelist: HTTP status codes that trigger a retry.
+
+    Returns
+    -------
+    requests.Response
+        Response object from ``requests``.
+    """
+
+    session = requests.Session()
+    retry = Retry(total=retries, backoff_factor=backoff_factor, status_forcelist=status_forcelist)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    log.debug(f"HTTP {method.upper()} request to {url} with timeout={timeout}")
+    response = session.request(method, url, timeout=timeout, **kwargs)
+    return response

--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -2,7 +2,8 @@ import json
 import logging
 
 import requests
-from open_webui.config import WEBUI_FAVICON_URL
+from open_webui.utils.http import http_request_with_retry
+from open_webui.config import WEBUI_FAVICON_URL, HTTP_REQUEST_TIMEOUT
 from open_webui.env import SRC_LOG_LEVELS, VERSION
 
 log = logging.getLogger(__name__)
@@ -51,7 +52,9 @@ def post_webhook(name: str, url: str, message: str, event_data: dict) -> bool:
             payload = {**event_data}
 
         log.debug(f"payload: {payload}")
-        r = requests.post(url, json=payload)
+        r = http_request_with_retry(
+            "post", url, json=payload, timeout=HTTP_REQUEST_TIMEOUT.value
+        )
         r.raise_for_status()
         log.debug(f"r.text: {r.text}")
         return True


### PR DESCRIPTION
## Summary
- create `http_request_with_retry` utility with timeout and retry support
- allow timeout customization via new `HTTP_REQUEST_TIMEOUT` config
- document `HTTP_REQUEST_TIMEOUT` in README
- switch many direct `requests` calls to use the helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_684203976c70833394539afd5a87545e