### PR TITLE
Add BMI endpoint with validation and multilingual responses

### DIFF
--- a/backend/open_webui/test/apps/webui/routers/test_bmi.py
+++ b/backend/open_webui/test/apps/webui/routers/test_bmi.py
@@ -1,0 +1,40 @@
+from test.util.abstract_integration_test import (
+    AbstractIntegrationTest,
+    get_fast_api_client,
+)
+
+
+class TestBMI(AbstractIntegrationTest):
+    BASE_PATH = "/bmi"
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.fast_api_client = get_fast_api_client()
+
+    def test_calculate_bmi(self):
+        response = self.fast_api_client.post(
+            self.create_url(""),
+            json={
+                "weight_kg": 70,
+                "height_m": 1.75,
+                "age": 30,
+                "gender": "male",
+                "pregnant": False,
+                "athlete": False,
+                "waist_cm": 80,
+                "lang": "es",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["bmi"] == round(70 / (1.75**2), 2)
+        assert data["category"] == "Peso normal"
+        assert data["group"] == "Adulto"
+
+    def test_missing_fields(self):
+        response = self.fast_api_client.post(
+            self.create_url(""),
+            json={"height_m": 1.8, "age": 25, "gender": "male"},
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add `/bmi` POST endpoint to compute BMI with category and group translations
- support basic validation and Spanish/English responses
- include tests for BMI endpoint

## Testing
- `PYTHONPATH=backend/open_webui pytest backend/open_webui/test/apps/webui/routers/test_bmi.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fa2bce788333a459d5008a6d275b

## Summary by Sourcery

Add a new /bmi endpoint to compute BMI with input validation, classification into category and group, and support for English and Spanish responses, along with integration tests.

New Features:
- Implement POST /bmi endpoint with BMI calculation, category/group assignment, and multilingual (en/es) output

Tests:
- Add integration tests for the /bmi endpoint covering valid requests and missing field validation errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a BMI calculation API (POST /bmi). Accepts weight, height, age, gender, pregnancy/athlete flags, optional waist, and language. Validates inputs and returns BMI (2 decimals), category (underweight/normal/overweight/obese), and group (adult/pregnant/child/athlete). Supports localization in English and Spanish (defaults to English). Existing endpoints unchanged.
- Tests
  - Introduced integration tests for successful BMI computation (including Spanish localization) and validation errors for incomplete requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->